### PR TITLE
Build the mmc driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(CONFIG_HAS_MCUX OR CONFIG_HAS_IMX_HAL)
-  zephyr_library()
+  zephyr_library_named(__modules__hal__nxp)
 endif()
 
 add_subdirectory_ifdef(

--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -138,9 +138,11 @@ include_driver_ifdef(CONFIG_MCUX_LPTMR_TIMER		lptmr		driver_lptmr)
 
 if(CONFIG_EMMC_USDHC)
   list(APPEND CMAKE_MODULE_PATH
+      ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/components/lists
+      ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/components/osa
+      ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/drivers/usdhc
       ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/middleware/sdmmc
   )
-  zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/middleware/sdmmc)
   include(middleware_sdmmc_mmc)
   include(middleware_sdmmc_host_usdhc_zephyr)
 endif()

--- a/mcux/hal_nxp.cmake
+++ b/mcux/hal_nxp.cmake
@@ -136,6 +136,15 @@ include_driver_ifdef(CONFIG_COUNTER_MCUX_SNVS_SRTC	snvs_lp		driver_snvs_lp)
 include_driver_ifdef(CONFIG_COUNTER_MCUX_LPTMR		lptmr		driver_lptmr)
 include_driver_ifdef(CONFIG_MCUX_LPTMR_TIMER		lptmr		driver_lptmr)
 
+if(CONFIG_EMMC_USDHC)
+  list(APPEND CMAKE_MODULE_PATH
+      ${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/middleware/sdmmc
+  )
+  zephyr_include_directories(${CMAKE_CURRENT_LIST_DIR}/mcux-sdk/middleware/sdmmc)
+  include(middleware_sdmmc_mmc)
+  include(middleware_sdmmc_host_usdhc_zephyr)
+endif()
+
 if ((${MCUX_DEVICE} MATCHES "MIMXRT1[0-9][0-9][0-9]") AND (NOT (CONFIG_SOC_MIMXRT1166_CM4 OR CONFIG_SOC_MIMXRT1176_CM4)))
   include_driver_ifdef(CONFIG_HAS_MCUX_CACHE		cache/armv7-m7	driver_cache_armv7_m7)
 elseif(${MCUX_DEVICE} MATCHES "MIMXRT(5|6)")

--- a/mcux/mcux-sdk/components/osa/component_osa_zephyr.cmake
+++ b/mcux/mcux-sdk/components/osa/component_osa_zephyr.cmake
@@ -1,4 +1,4 @@
-#Description: Component osa_bm; user_visible: False
+#Description: Component osa_zephyr; user_visible: False
 include_guard(GLOBAL)
 message("component_osa_zephyr component is included.")
 

--- a/mcux/mcux-sdk/components/osa/component_osa_zephyr.cmake
+++ b/mcux/mcux-sdk/components/osa/component_osa_zephyr.cmake
@@ -1,0 +1,14 @@
+#Description: Component osa_bm; user_visible: False
+include_guard(GLOBAL)
+message("component_osa_zephyr component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/fsl_os_abstraction_zephyr.c
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(component_lists)

--- a/mcux/mcux-sdk/components/osa/fsl_os_abstraction.h
+++ b/mcux/mcux-sdk/components/osa/fsl_os_abstraction.h
@@ -113,6 +113,10 @@ typedef enum _osa_status
 #define OSA_MUTEX_HANDLE_SIZE (4U)
 #define OSA_MSGQ_HANDLE_SIZE  (4U)
 #define OSA_MSG_HANDLE_SIZE   (0U)
+#elif defined(SDK_OS_ZEPHYR)
+#define USE_RTOS (1)
+#include <kernel.h>
+#define OSA_MUTEX_HANDLE_SIZE sizeof(struct k_mutex)
 #elif defined(SDK_OS_UCOSII)
 #define USE_RTOS (1)
 #elif defined(SDK_OS_UCOSIII)
@@ -350,6 +354,8 @@ typedef enum _osa_status
 
 #if defined(SDK_OS_FREE_RTOS)
 #include "fsl_os_abstraction_free_rtos.h"
+#elif defined(SDK_OS_ZEPHYR)
+#include "fsl_os_abstraction_zephyr.h"
 #elif defined(FSL_RTOS_THREADX)
 #include "fsl_os_abstraction_threadx.h"
 #else

--- a/mcux/mcux-sdk/components/osa/fsl_os_abstraction.h
+++ b/mcux/mcux-sdk/components/osa/fsl_os_abstraction.h
@@ -113,10 +113,11 @@ typedef enum _osa_status
 #define OSA_MUTEX_HANDLE_SIZE (4U)
 #define OSA_MSGQ_HANDLE_SIZE  (4U)
 #define OSA_MSG_HANDLE_SIZE   (0U)
-#elif defined(SDK_OS_ZEPHYR)
+#elif defined(__ZEPHYR__)
 #define USE_RTOS (1)
 #include <kernel.h>
 #define OSA_MUTEX_HANDLE_SIZE sizeof(struct k_mutex)
+#define OSA_SEM_HANDLE_SIZE sizeof(struct k_sem)
 #elif defined(SDK_OS_UCOSII)
 #define USE_RTOS (1)
 #elif defined(SDK_OS_UCOSIII)
@@ -354,7 +355,7 @@ typedef enum _osa_status
 
 #if defined(SDK_OS_FREE_RTOS)
 #include "fsl_os_abstraction_free_rtos.h"
-#elif defined(SDK_OS_ZEPHYR)
+#elif defined(__ZEPHYR__)
 #include "fsl_os_abstraction_zephyr.h"
 #elif defined(FSL_RTOS_THREADX)
 #include "fsl_os_abstraction_threadx.h"

--- a/mcux/mcux-sdk/components/osa/fsl_os_abstraction_zephyr.c
+++ b/mcux/mcux-sdk/components/osa/fsl_os_abstraction_zephyr.c
@@ -1,0 +1,88 @@
+#include "fsl_os_abstraction.h"
+#include "fsl_os_abstraction_zephyr.h"
+
+/*FUNCTION**********************************************************************
+*
+* Function Name : OSA_MutexCreate
+* Description   : This function is used to create a mutex.
+* Return        : Mutex handle of the new mutex, or NULL if failed.
+*
+* END**************************************************************************/
+osa_status_t OSA_MutexCreate(osa_mutex_handle_t mutexHandle)
+{
+  assert(NULL != mutexHandle);
+  k_mutex_init((struct k_mutex *)mutexHandle);
+  return KOSA_StatusSuccess;
+}
+
+/*FUNCTION**********************************************************************
+*
+* Function Name : OSA_MutexLock
+* Description   : This function checks the mutex's status, if it is unlocked,
+* lock it and returns KOSA_StatusSuccess, otherwise, wait for the mutex.
+* This function returns KOSA_StatusSuccess if the mutex is obtained, returns
+* KOSA_StatusError if any errors occur during waiting. If the mutex has been
+* locked, pass 0 as timeout will return KOSA_StatusTimeout immediately.
+*
+* END**************************************************************************/
+osa_status_t OSA_MutexLock(osa_mutex_handle_t mutexHandle, uint32_t millisec)
+{
+  assert(mutexHandle);
+  k_timeout_t timeout;
+  osa_status_t status = KOSA_StatusSuccess;
+
+  /* Convert timeout from millisecond to tick. */
+  if (millisec == osaWaitForever_c) {
+    timeout = K_FOREVER;
+  } else {
+    timeout = K_MSEC(millisec);
+  }
+
+  if (k_mutex_lock((struct k_mutex *)mutexHandle, timeout) != 0) {
+    status = KOSA_StatusError;
+  }
+  return status;
+}
+
+/*FUNCTION**********************************************************************
+*
+* Function Name : OSA_MutexUnlock
+* Description   : This function is used to unlock a mutex.
+*
+* END**************************************************************************/
+osa_status_t OSA_MutexUnlock(osa_mutex_handle_t mutexHandle)
+{
+  assert(mutexHandle);
+  osa_status_t status = KOSA_StatusSuccess;
+
+  if (k_mutex_unlock((struct k_mutex *)mutexHandle) != 0) {
+    status = KOSA_StatusError;
+  }
+  return status;
+}
+
+/*FUNCTION**********************************************************************
+*
+* Function Name : OSA_MutexDestroy
+* Description   : This function is used to destroy a mutex.
+* Return        : KOSA_StatusSuccess if the lock object is destroyed successfully, otherwise
+*   return KOSA_StatusError.
+*
+* END**************************************************************************/
+osa_status_t OSA_MutexDestroy(osa_mutex_handle_t mutexHandle)
+{
+  assert(mutexHandle);
+  return KOSA_StatusSuccess;
+}
+
+/*FUNCTION**********************************************************************
+*
+* Function Name : OSA_TimeDelay
+* Description   : This function is used to suspend the active thread for the given number of
+*   milliseconds.
+*
+* END**************************************************************************/
+void OSA_TimeDelay(uint32_t millisec)
+{
+  k_msleep(millisec);
+}

--- a/mcux/mcux-sdk/components/osa/fsl_os_abstraction_zephyr.c
+++ b/mcux/mcux-sdk/components/osa/fsl_os_abstraction_zephyr.c
@@ -1,6 +1,8 @@
 #include "fsl_os_abstraction.h"
 #include "fsl_os_abstraction_zephyr.h"
 
+#include <kernel.h>
+
 /*FUNCTION**********************************************************************
 *
 * Function Name : OSA_MutexCreate

--- a/mcux/mcux-sdk/components/osa/fsl_os_abstraction_zephyr.h
+++ b/mcux/mcux-sdk/components/osa/fsl_os_abstraction_zephyr.h
@@ -1,9 +1,4 @@
 #ifndef _FSL_OS_ABSTRACTION_ZEPHYR_H
 #define _FSL_OS_ABSTRACTION_ZEPHYR_H
 
-//#include <kernel.h>
-
-/*! @brief OSA mutex handle size. */
-//#define OSA_MUTEX_HANDLE_SIZE sizeof(struct k_mutex)
-
 #endif // _FSL_OS_ABSTRACTION_ZEPHYR_H

--- a/mcux/mcux-sdk/components/osa/fsl_os_abstraction_zephyr.h
+++ b/mcux/mcux-sdk/components/osa/fsl_os_abstraction_zephyr.h
@@ -1,0 +1,9 @@
+#ifndef _FSL_OS_ABSTRACTION_ZEPHYR_H
+#define _FSL_OS_ABSTRACTION_ZEPHYR_H
+
+//#include <kernel.h>
+
+/*! @brief OSA mutex handle size. */
+//#define OSA_MUTEX_HANDLE_SIZE sizeof(struct k_mutex)
+
+#endif // _FSL_OS_ABSTRACTION_ZEPHYR_H


### PR DESCRIPTION
1) Adds os abstraction for zephyr to mcux-sdk, similar to [bare metal osa](https://github.com/whisperai/hal_nxp/blob/nahal/zephyr_3_hal_nxp/mcux/mcux-sdk/components/osa/component_osa_bm.cmake). Only the apis used in the nxp mmc driver are implemented for now.

2) Pulls in the `middleware_sdmmc_mmc` driver into hal_nxp module if `CONFIG_EMMC_USDHC` is set. Assumes the sdmmc driver is under `mcux/mcux-sdk/middleware/sdmmc`.

How the cmake files are linked:
`mcux/hal_nxp.cmake` includes `middleware_sdmmc_mmc.cmake` and `middleware_sdmmc_host_usdhc_zephyr` in `mcux/mcux-sdk/middleware/sdmmc/` which eventually include `component_osa_zephyr` in `mcux/mcux-sdk/components/osa/` and `driver_usdhc` in `mcux/mcux-sdk/drivers/usdhc/`


